### PR TITLE
add modern CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ add_library(meshb sources/libmeshb7.c)
 target_include_directories(meshb PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/sources>
     $<INSTALL_INTERFACE:include>)
+# using aio functions requires a "-lrt" flag
+target_link_libraries(meshb rt)
 install(TARGETS meshb EXPORT meshb-target DESTINATION lib)
 install(EXPORT meshb-target NAMESPACE ${PROJECT_NAME}::
     DESTINATION lib/cmake/${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.0.0)
+
+project(Meshb VERSION 7.12 LANGUAGES C)
+
+add_library(meshb sources/libmeshb7.c)
+target_include_directories(meshb PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/sources>
+    $<INSTALL_INTERFACE:include>)
+install(TARGETS meshb EXPORT meshb-target DESTINATION lib)
+install(EXPORT meshb-target NAMESPACE ${PROJECT_NAME}::
+    DESTINATION lib/cmake/${PROJECT_NAME})
+install(FILES sources/libmeshb7.h DESTINATION include)
+
+include(CMakePackageConfigHelpers)
+file(WRITE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+    "include(\${CMAKE_CURRENT_LIST_DIR}/meshb-target.cmake)")
+write_basic_package_version_file(
+    "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion)
+install(FILES
+    "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    DESTINATION lib/cmake/${PROJECT_NAME})


### PR DESCRIPTION
This CMake file will compile and install
libMeshb in the include/ and lib/ directories,
also it will install files in lib/cmake/
that allow users compiling with CMake to
find and link to libMeshb.