### PR TITLE
CMake: update version to 7.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0.0)
 
-project(Meshb VERSION 7.12 LANGUAGES C)
+project(Meshb VERSION 7.15 LANGUAGES C)
 
 add_library(meshb sources/libmeshb7.c)
 target_include_directories(meshb PUBLIC


### PR DESCRIPTION
for CMake consistency with the
new libMeshb version number
