### PR TITLE
Check languages before other logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,14 @@ cmake_minimum_required (VERSION 3.0.1)
 set (libMeshb_VERSION_MAJOR 7)
 set (libMeshb_VERSION_MINOR 24)
 
+project(libMeshb VERSION "${libMeshb_VERSION_MAJOR}.${libMeshb_VERSION_MINOR}" LANGUAGES C)
+
+include (CheckLanguage)
+check_language (Fortran)
+if(CMAKE_Fortran_COMPILER)
+  enable_language(Fortran)
+endif()
+
 if (WIN32)
    set (CMAKE_C_FLAGS -DWIN32)
    set (CMAKE_CONFIGURATION_TYPES Release)
@@ -24,12 +32,6 @@ else ()
 endif ()
 
 project (libMeshb VERSION ${libMeshb_VERSION_MAJOR}.${libMeshb_VERSION_MINOR} LANGUAGES C)
-
-include (CheckLanguage)
-check_language (Fortran)
-if(CMAKE_Fortran_COMPILER)
-  enable_language(Fortran)
-endif()
 
 
 #######################################


### PR DESCRIPTION
Without this change, CMAKE_C_FLAGS
gets overwritten to something other
than the intended "-O3"