### PR TITLE
add travis-ci feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,13 @@ install:
   - mkdir build
   - cd build
   
-before_script : cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
 
 jobs:
   include:
-      - if: os = windows
+      - before_script : cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
+      - if: (dist IN (trusty,bionic) OR os = osx)
       - before_script : cmake -DCMAKE_INSTALL_PREFIX=%HOMEPATH%\local ..\
+      - if: os = windows
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: c
 
 compiler:
-  - cmake
   - gcc
 
 before_script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,3 @@ before_script:
 
 script:
   - make
-
-install:
-  - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,20 +19,8 @@ matrix:
 install: 
   - mkdir build
   - cd build
-  
 
-jobs:
-  include:
-      - dist: trusty
-      - before_script : cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
-      - dist: bionic
-      - before_script : cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
-      - os: osx
-      - before_script : cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
-      - if: (dist IN (trusty,bionic) OR os = osx)
-      - os: windows
-      - before_script : cmake -DCMAKE_INSTALL_PREFIX=%HOMEPATH%\local ..\
-      - if: os = windows
+before_script : cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,14 @@ install:
 
 jobs:
   include:
+      - dist: trusty
       - before_script : cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
+      - dist: bionic
       - before_script : cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
+      - os: osx
       - before_script : cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
       - if: (dist IN (trusty,bionic) OR os = osx)
+      - os: windows
       - before_script : cmake -DCMAKE_INSTALL_PREFIX=%HOMEPATH%\local ..\
       - if: os = windows
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,10 @@ install:
 
 jobs:
   include:
-      if: dist in (trusty,bionic) OR os = osx
-      before_script :
-        - cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
+      - before_script : cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
+      if: (dist IN (trusty,bionic)) OR (os = osx)
+      - before_script : cmake -DCMAKE_INSTALL_PREFIX=%HOMEPATH%\local ..\
       if: os = windows
-      before_script :
-        - cmake -DCMAKE_INSTALL_PREFIX=%HOMEPATH%\local ..\
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,24 @@ language: c
 compiler:
   - gcc
 
-before_script: 
+matrix:
+  include:
+    # Ubuntu Trusty, Xenial and Bionic
+    - os: linux
+      dist:trusty
+
+    - os: linux
+      dist:bionic
+
+    # MacOs
+    - os: osx
+
+    # Windows
+#    - os: windows
+#      env:
+#         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+
+install: 
   - mkdir build
   - cd build
   - cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ compiler:
 before_script: 
   - mkdir build
   - cd build
-  - cmake --build . --config Release --target INSTALL
+  - cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../L
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ before_script : cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
 
 jobs:
   include:
-      - before_script : cmake -DCMAKE_INSTALL_PREFIX=%HOMEPATH%\local ..\
       - if: os = windows
+      - before_script : cmake -DCMAKE_INSTALL_PREFIX=%HOMEPATH%\local ..\
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ before_script:
 
 script:
   - make
+
+install:
+  - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,20 @@ matrix:
     - os: osx
 
     # Windows
-#    - os: windows
-#      env:
-#         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+    - os: windows
 
 install: 
   - mkdir build
   - cd build
-  - cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
+
+jobs:
+  include:
+      if: dist in (trusty,bionic) OR os = osx
+      before_script :
+        - cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
+      if: os = windows
+      before_script :
+        - cmake -DCMAKE_INSTALL_PREFIX=%HOMEPATH%\local ..\
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,3 @@ before_script:
 
 script:
   - make
-
-install:
-  - cd build
-  - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,5 @@ script:
   - make
 
 install:
+  - cd build
   - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script : cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
 
 jobs:
   include:
-      - before_script : cmake -DCMAKE_INSTALL_PREFIX=%HOMEPATH%\local ..\
+      before_script : cmake -DCMAKE_INSTALL_PREFIX=%HOMEPATH%\local ..\
       if: os = windows
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,11 @@ matrix:
 install: 
   - mkdir build
   - cd build
+  
+before_script : cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
 
 jobs:
   include:
-      - before_script : cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
-      if: (dist IN (trusty,bionic)) OR (os = osx)
       - before_script : cmake -DCMAKE_INSTALL_PREFIX=%HOMEPATH%\local ..\
       if: os = windows
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - os: osx
 
     # Windows
-    - os: windows
+    # - os: windows
 
 install: 
   - mkdir build
@@ -23,10 +23,12 @@ install:
 
 jobs:
   include:
-      - if: (dist IN (trusty,bionic) OR os = osx)
       - before_script : cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
-      - if: os = windows
+      - before_script : cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
+      - before_script : cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
+      - if: (dist IN (trusty,bionic) OR os = osx)
       - before_script : cmake -DCMAKE_INSTALL_PREFIX=%HOMEPATH%\local ..\
+      - if: os = windows
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ install:
 
 jobs:
   include:
-      - before_script : cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
       - if: (dist IN (trusty,bionic) OR os = osx)
-      - before_script : cmake -DCMAKE_INSTALL_PREFIX=%HOMEPATH%\local ..\
+      - before_script : cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
       - if: os = windows
+      - before_script : cmake -DCMAKE_INSTALL_PREFIX=%HOMEPATH%\local ..\
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: c
+
+compiler:
+  - cmake
+  - gcc
+
+before_script: 
+  - mkdir build
+  - cd build
+  - cmake --build . --config Release --target INSTALL
+
+script:
+  - make
+
+install:
+  - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,9 @@ compiler:
 matrix:
   include:
     # Ubuntu Trusty, Xenial and Bionic
-    - os: linux
-      dist:trusty
+    - dist: trusty
 
-    - os: linux
-      dist:bionic
+    - dist: bionic
 
     # MacOs
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ compiler:
 before_script: 
   - mkdir build
   - cd build
-  - cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../L
+  - cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ before_script : cmake -DCMAKE_INSTALL_PREFIX=$HOME/local ../
 
 jobs:
   include:
-      before_script : cmake -DCMAKE_INSTALL_PREFIX=%HOMEPATH%\local ..\
-      if: os = windows
+      - before_script : cmake -DCMAKE_INSTALL_PREFIX=%HOMEPATH%\local ..\
+      - if: os = windows
 
 script:
   - make


### PR DESCRIPTION
Travis-ci is a free and online continuous integration/build server.
On each git push , travis pull and build all the project.
The current defaut build environment is Linux/Ubuntu 16.04.6 LTS xenial , gcc (Ubuntu 5.4.0-6ubuntu1~16.04.11) 5.4.0 20160609

We can enhance the build process with different system : mac os , linux version, windows (???)