### PR TITLE
Update libmeshb7.c

### DIFF
--- a/sources/libmeshb7.c
+++ b/sources/libmeshb7.c
@@ -1151,6 +1151,16 @@ int NAMF77(GmfSetLin, gmfsetlin)(TYPF77(int64_t) MshIdx, TYPF77(int) KwdCod, ...
 
    if( ( VALF77(KwdCod) < 1) || ( VALF77(KwdCod) > GmfMaxKwd) )
       return(0);
+ 
+   // Save the current stack environment for longjmp
+   // This is needed in RecBlk()
+   if( (err = setjmp(msh->err)) != 0)
+   {
+#ifdef GMFDEBUG
+      printf("libMeshb : mesh %p : error %d\n", msh, err);
+#endif
+      return(0);
+   }
 
    // Start decoding the arguments
    va_start(VarArg, KwdCod);


### PR DESCRIPTION
hi,

I propose to add a setjmp() in gmfsetlin(), otherwise write errors in RecBlk() would cause a jump to somewhere else, such as GmfOpenMesh() where it causes a segfault due to uninitialized variables.

Best regards,
Mark
