### PR TITLE
CMAKE_Fortran_MODULE_DIRECTORY Handling When Fortran Compiler Is Not Found

### DIFF
--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -22,7 +22,9 @@ install (EXPORT meshb-target NAMESPACE ${PROJECT_NAME}::
 
 install (TARGETS Meshb.7 EXPORT libMeshb-target DESTINATION lib COMPONENT libraries)
 
-install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/ DESTINATION include)
+if(CMAKE_Fortran_COMPILER)
+  install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/ DESTINATION include)
+endif()
 
 install (EXPORT libMeshb-target DESTINATION lib/cmake/${PROJECT_NAME})
 


### PR DESCRIPTION
### Problem:
The issue arises when the Fortran compiler is not found or is unavailable. In this case:
- **`CMAKE_Fortran_MODULE_DIRECTORY`** is intended to specify the directory for Fortran module files.
- However, when no Fortran compiler is detected (`CMAKE_Fortran_COMPILER_NOTFOUND`), **`CMAKE_Fortran_MODULE_DIRECTORY`** is left empty.
- As a result, when the install command 
```cmake
  install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/ DESTINATION include)
```
is executed, it attempts to copy files from the **root directory** (`/`), leading to unintended consequences, such as attempting to install files from the root filesystem, potentially installing incorrect files or causing permission issues.

