### PR TITLE
define the RequiredTetrahedra keyword with binary tag 12, as in mmg3d

### DIFF
--- a/sources/libmeshb8.c
+++ b/sources/libmeshb8.c
@@ -235,8 +235,8 @@ typedef struct
 
 const char *GmfKwdFmt[ GmfMaxKwd + 1 ][3] = 
 {
-   {"Reserved",                                 "", ""},
-   {"MeshVersionFormatted",                     "", "i"},
+   {"Reserved",                                 "", ""},       // 0
+   {"MeshVersionFormatted",                     "", "i"},      // 1
    {"Reserved",                                 "", ""},
    {"Dimension",                                "", "i"},
    {"Vertices",                                 "i", "dri"},
@@ -247,7 +247,7 @@ const char *GmfKwdFmt[ GmfMaxKwd + 1 ][3] =
    {"Prisms",                                   "i", "iiiiiii"},
    {"Hexahedra",                                "i", "iiiiiiiii"},
    {"Reserved",                                 "",  ""},
-   {"Reserved",                                 "",  ""},
+   {"RequiredTetrahedra",                       "i", "i"}, // 12 as in mmg
    {"Corners",                                  "i", "i"},
    {"Ridges",                                   "i", "i"},
    {"RequiredVertices",                         "i", "i"},

--- a/sources/libmeshb8.h
+++ b/sources/libmeshb8.h
@@ -66,6 +66,7 @@ enum GmfKwdCod
    GmfHexahedra,
    GmfReserved3,
    GmfReserved4,
+   GmfRequiredTetrahedra,
    GmfCorners,
    GmfRidges,
    GmfRequiredVertices,


### PR DESCRIPTION
This MR defines the RequiredTetrahedra keyword with binary tag 12. This tag was Reserved. The value is the one that I found in the mmg3d software. libMeshb had several types of Required entities, but this one was missing and I actually needed it.

BTW I wanted to propose the inclusion of several keywords for the distributed mesh format that parMmg is using, but 1) their binary tags are already used for other things in libMeshb, and 2) I think they need to be revised. So I'll come up with that later but I hope they can be included in version 8.
