### PR TITLE
Add missing include.

### DIFF
--- a/examples/preprocessing_pipeline.c
+++ b/examples/preprocessing_pipeline.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
+#include <string.h>
 #include <strings.h>
 #include <math.h>
 #include <float.h>


### PR DESCRIPTION
Build was failing with gcc (but not clang) and adding `<string.h>` include fixed it.